### PR TITLE
Updated grunt-contrib-copy to version 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "grunt-scaffold",
   "description": "Scaffold what you want.",
   "version": "0.1.3",
-
   "homepage": "https://github.com/crudo/grunt-scaffold",
-
   "author": {
     "name": "crudo",
     "email": "crudo@crudo.cz"
@@ -32,14 +30,20 @@
     "grunt-contrib-jshint": "~0.7.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-nodeunit": "~0.2.2",
-    "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-copy": "0.8.1",
     "grunt": "~0.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"
   },
   "keywords": [
-    "gruntplugin", "scaffold", "scaffolding", "create", "setup", "interactive", "skeleton"
+    "gruntplugin",
+    "scaffold",
+    "scaffolding",
+    "create",
+    "setup",
+    "interactive",
+    "skeleton"
   ],
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
:rocket:

grunt-contrib-copy just published version 0.8.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>