### PR TITLE
Allow template to be specified as a function

### DIFF
--- a/tasks/scaffold.js
+++ b/tasks/scaffold.js
@@ -29,6 +29,10 @@ module.exports = function(grunt) {
                 result = options.filter(result);
             }
 
+            if (_.isFunction(template)) {
+                template = template(result);
+            }
+
             Object.keys(template).forEach(function(key){
                 var dist = mustache.render(template[key], result),
                     distDir = path.dirname(dist);


### PR DESCRIPTION
This change makes it possible to specify the template option in the configuration hash to be a function so that based on the questions one or more files can be conditionally included/excluded.